### PR TITLE
adding nodezoo-updater, dequeue -> Do not merge until:

### DIFF
--- a/fuge/fuge-config.js
+++ b/fuge/fuge-config.js
@@ -61,6 +61,16 @@ module.exports = {
       build: 'npm install'
     },
 
+    nodezoo_updater: {
+      run: 'node srv/start.js',
+      build: 'npm install'
+    },
+
+    nodezoo_dequeue: {
+      run: 'node srv/start.js',
+      build: 'npm install'
+    },
+
     nodezoo_web: {
       run: 'node server/start.js',
       build: 'npm install; npm run build'

--- a/fuge/system.yml
+++ b/fuge/system.yml
@@ -53,7 +53,7 @@ nodezoo_travis:
   restart: always
 
 nodezoo_updater:
-  build: ../node_modules/nodezoo-npm-update/
+  build: ../node_modules/nodezoo-updater/
   container_name: nodezoo_updater
   env_file: ../system.env
   net: host

--- a/fuge/system.yml
+++ b/fuge/system.yml
@@ -52,6 +52,18 @@ nodezoo_travis:
   net: host
   restart: always
 
+nodezoo_updater:
+  build: ../node_modules/nodezoo-npm-update/
+  container_name: nodezoo_updater
+  env_file: ../system.env
+  net: host
+
+nodezoo_dequeue:
+  build: ../node_modules/nodezoo-dequeue/
+  container_name: nodezoo_dequeue
+  env_file: ../system.env
+  net: host
+
 nodezoo_web:
   build: ../node_modules/nodezoo-web/
   container_name: nodezoo_web

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "nodezoo-search": "6.0.0",
     "nodezoo-travis": "6.0.0",
     "nodezoo-web": "6.0.0",
-    "nodezoo-updater": "1.0.0"
+    "nodezoo-updater": "1.0.0",
+    "nodezoo-dequeue": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "nodezoo-npm": "6.0.0",
     "nodezoo-search": "6.0.0",
     "nodezoo-travis": "6.0.0",
-    "nodezoo-web": "6.0.0"
+    "nodezoo-web": "6.0.0",
+    "nodezoo-updater": "1.0.0"
   }
 }

--- a/sample.env
+++ b/sample.env
@@ -6,3 +6,8 @@
 
 # An api authorization from github, (requires read only rights)
 GITHUB_TOKEN=
+
+## nodezoo-updater
+
+# Limit how many modules are processed by the registryDownload cmd; 0 processes the entire registry
+UPDATER_LIMIT=0


### PR DESCRIPTION
Depends on 

[nodezoo-dequeue PR 4](https://github.com/nodezoo/nodezoo-dequeue/pull/4)
nodezoo-dequeue npm publish (if the version isn't 1.0.0, I need to change package.json)

https://github.com/nodezoo/nodezoo-npm-update/issues/9
https://github.com/nodezoo/nodezoo-npm-update/issues/11
nodezoo-updater publish to npm (if the version isn't 1.0.0, I need to change package.json)

Since I have this locally, I wanted to push a PR on it for later. 
